### PR TITLE
Add list of value files

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -44,4 +44,5 @@ resource gitops_module module {
   branch = local.application_branch
   config = yamlencode(var.gitops_config)
   credentials = yamlencode(var.git_credentials)
+  value_files = "values.yaml,${local.values_file}"
 }


### PR DESCRIPTION
After reviewing the go code for the gitops provider, it appears that the `value-files` parameter for **igc** is supported.

Update this module to provide the standard and customized value files to pass along to **igc**

fixes #9 
Signed-off-by: Tim Robinson <timroster@gmail.com>